### PR TITLE
Fixed translation

### DIFF
--- a/pyscbwrapper_en.ipynb
+++ b/pyscbwrapper_en.ipynb
@@ -292,7 +292,6 @@
       },
       "cell_type": "markdown",
       "source": [
-        "Oops! Vi ville inte titta på namnstatistiken utan befolkningsstatistiken. Vi går upp ett steg igen och vidare ned till rätt nod: \n",
         "Whoops! We did not want the name statistics, but the population statistics. We go up one step and back down to the correct node: "
       ]
     },


### PR DESCRIPTION
Fixed a line where there was both a Swedish and a English version of the same sentence. Deleted the Swedish version.